### PR TITLE
Fetch classpathscanner from real jitstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ slashgif
 
 Usage
 -----
-1. clone and mvn install https://github.com/RichoDemus/guice-classpath-scanning (because richo is lazy and havent made a release)
-2. mvn clean package -T1C && java -jar web/target/web-1.0-SNAPSHOT.jar server web/config.yaml
+1. mvn clean package -T1C && java -jar web/target/web-1.0-SNAPSHOT.jar server web/config.yaml
 
 URLs
 ----

--- a/pom.xml
+++ b/pom.xml
@@ -108,9 +108,9 @@
 			</dependency>
 
 			<dependency>
-				<groupId>com.github.richodemus.guice-classpath-scanning</groupId>
-				<artifactId>guice-classpath-scanner</artifactId>
-				<version>1.0-SNAPSHOT</version>
+				<groupId>com.github.RichoDemus</groupId>
+				<artifactId>guice-classpath-scanning</artifactId>
+				<version>b7e7f87a04</version>
 			</dependency>
 
 			<dependency>
@@ -150,15 +150,29 @@
 						<configuration>
 							<failOnWarning>true</failOnWarning>
 							<ignoredUnusedDeclaredDependencies>
-								<ignoredUnusedDeclaredDependency>org.slf4j:slf4j-simple
+								<!-- If we want logging in a unit-test -->
+								<ignoredUnusedDeclaredDependency>
+									ch.qos.logback:logback-classic
 								</ignoredUnusedDeclaredDependency>
-								<ignoredUnusedDeclaredDependency>ch.qos.logback:logback-classic
+								<!-- Never referenced, scanned by guice -->
+								<ignoredUnusedDeclaredDependency>
+									com.github.tsar-industries.slashgif:google-image-search
 								</ignoredUnusedDeclaredDependency>
-								<ignoredUnusedDeclaredDependency>com.github.tsar-industries.slashgif:google-image-search
+								<!-- Never referenced, scanned by guice -->
+								<ignoredUnusedDeclaredDependency>
+									com.github.tsar-industries.slashgif:service
 								</ignoredUnusedDeclaredDependency>
-								<ignoredUnusedDeclaredDependency>com.github.tsar-industries.slashgif:service
+								<!-- Weird stuff, see https://github.com/TSAR-Industries/slashgif/issues/6#issuecomment-148947122 -->
+								<ignoredUnusedDeclaredDependency>
+									com.github.RichoDemus:guice-classpath-scanning
 								</ignoredUnusedDeclaredDependency>
 							</ignoredUnusedDeclaredDependencies>
+							<ignoredUsedUndeclaredDependencies>
+								<!-- Weird stuff, see https://github.com/TSAR-Industries/slashgif/issues/6#issuecomment-148947122 -->
+								<ignoreUsedUndeclaredDependency>
+									com.github.RichoDemus.guice-classpath-scanning:guice-classpath-scanner
+								</ignoreUsedUndeclaredDependency>
+							</ignoredUsedUndeclaredDependencies>
 						</configuration>
 					</execution>
 				</executions>
@@ -224,4 +238,10 @@
 			</plugins>
 		</pluginManagement>
 	</build>
+	<repositories>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
+	</repositories>
 </project>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -36,8 +36,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.github.richodemus.guice-classpath-scanning</groupId>
-			<artifactId>guice-classpath-scanner</artifactId>
+			<groupId>com.github.RichoDemus</groupId>
+			<artifactId>guice-classpath-scanning</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>javax.inject</groupId>


### PR DESCRIPTION
Previously you had to clone the repo with the classpathscanner and build it before you could build slashgif, now we use jitpack.io to fetch it. 
I know it's ugly with the whole "ignoredUnusedDeclaredDependencies"-tag in the pom but it'll be fixed once/when I actually do a proper release of the classpath scanning.

this fixes #6
